### PR TITLE
Fix iOS `Stripe` SDK version

### DIFF
--- a/ios/stripe_payment.podspec
+++ b/ios/stripe_payment.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Stripe'
+  s.dependency 'Stripe', '15.0.1'
 
   s.ios.deployment_target = '8.0'
 end


### PR DESCRIPTION
I faced this issue https://github.com/jonasbark/flutter_stripe_payment/issues/30

This problem is because stripe ios sdk ( https://github.com/stripe/stripe-ios/releases/tag/v16.0.0 ) changed a lot since v1.6.0.

This flutter repo is coded on the the premise that the version is before v1.6.0.  So I fix the version 15.0.1 in the podspec. 

This is a quick update.
