### PR TITLE
unfinished Apple Pay native payment confirmation

### DIFF
--- a/android/src/main/kotlin/de/jonasbark/stripepayment/StripePaymentPlugin.kt
+++ b/android/src/main/kotlin/de/jonasbark/stripepayment/StripePaymentPlugin.kt
@@ -135,6 +135,9 @@ class StripePaymentPlugin(private val activity: FragmentActivity) : MethodCallHa
                 googlePay(total, currency)
 
             }
+            "nativeConfirm" - {
+                result.success(null)
+            }
             else -> result.notImplemented()
         }
     }

--- a/android/src/main/kotlin/de/jonasbark/stripepayment/StripePaymentPlugin.kt
+++ b/android/src/main/kotlin/de/jonasbark/stripepayment/StripePaymentPlugin.kt
@@ -135,7 +135,7 @@ class StripePaymentPlugin(private val activity: FragmentActivity) : MethodCallHa
                 googlePay(total, currency)
 
             }
-            "nativeConfirm" - {
+            "nativeConfirm" -> {
                 result.success(null)
             }
             else -> result.notImplemented()

--- a/ios/Classes/StripePaymentPlugin.m
+++ b/ios/Classes/StripePaymentPlugin.m
@@ -5,9 +5,9 @@
     FlutterResult flutterResult;
 }
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-    
+
     FlutterMethodChannel* channel = [FlutterMethodChannel methodChannelWithName:@"stripe_payment" binaryMessenger:[registrar messenger]];
-    
+
     StripePaymentPlugin* instance = [[StripePaymentPlugin alloc] init];
     [registrar addMethodCallDelegate:instance channel:channel];
 }
@@ -35,6 +35,15 @@
         NSString* currency = call.arguments[@"currency"];
 
         [self fetchNativeToken:subtotal tax:tax tip:tip currency:currency result:result];
+    }
+    else if ([@"nativeConfirm" isEqualToString:call.method]) {
+        PKPaymentAuthorizationStatus authStatus;
+        if (call.arguments[@"isSuccess"]) {
+            authStatus = PKPaymentAuthorizationStatusSuccess;
+        } else {
+            authStatus = PKPaymentAuthorizationStatusFailure;
+        }
+// XXX Here we need to call back the handler with the result and return success to flutter.... -- alexis@ww.net
     }
     else {
         result(FlutterMethodNotImplemented);
@@ -136,6 +145,8 @@
             self->flutterResult([FlutterError errorWithCode:error.localizedDescription message:nil details:nil]);
         }
         else {
+             // XXX Here we need save the handler callback -- alexis@ww.net
+
             self->flutterResult(token.tokenId);
         }
     }];

--- a/ios/stripe_payment.podspec
+++ b/ios/stripe_payment.podspec
@@ -17,5 +17,5 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   s.dependency 'Stripe', '17.0.2'
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '11.0'
 end

--- a/lib/stripe_payment.dart
+++ b/lib/stripe_payment.dart
@@ -43,6 +43,10 @@ class StripePayment {
     final String nativeToken = await _channel.invokeMethod('nativePay', orderMap);
     return nativeToken;
   }
+
+  static void confirmNativePayment(bool isSuccess) =>
+      _channel.invokeMethod("confirmNative", {"isSuccess": isSuccess});
+
 }
 
 class StripeSettings {

--- a/lib/stripe_payment.dart
+++ b/lib/stripe_payment.dart
@@ -45,7 +45,7 @@ class StripePayment {
   }
 
   static void confirmNativePayment(bool isSuccess) =>
-      _channel.invokeMethod("confirmNative", {"isSuccess": isSuccess});
+      _channel.invokeMethod("nativeConfirm", {"isSuccess": isSuccess});
 
 }
 


### PR DESCRIPTION
When doing native payments on iOS (Apple Pay) the iOS expects a call back with either failure or success of the payment.

Proposed is a channel method `nativeConfirm(bool isSuccess)`

I'm not familiar with Objective-C at all perhaps somebody could finish this?