### PR TITLE
Fixing incorrect type on canMakeNativePayPayments

### DIFF
--- a/lib/src/stripe_payment.dart
+++ b/lib/src/stripe_payment.dart
@@ -33,11 +33,11 @@ class StripePayment {
   }
 
   /// https://tipsi.github.io/tipsi-stripe/docs/canMakeNativePayPayments.html
-  static Future<bool> canMakeNativePayPayments(List<String> networks) async {
+  static Future<bool> canMakeNativePayPayments(Map<String, dynamic> options) async {
     if (Platform.isAndroid) {
       return _channel.invokeMethod('canMakeAndroidPayPayments');
     } else if (Platform.isIOS) {
-      return _channel.invokeMethod('canMakeApplePayPayments', networks);
+      return _channel.invokeMethod('canMakeApplePayPayments', options);
     } else
       throw UnimplementedError();
   }

--- a/lib/src/stripe_payment.dart
+++ b/lib/src/stripe_payment.dart
@@ -37,7 +37,7 @@ class StripePayment {
     if (Platform.isAndroid) {
       return _channel.invokeMethod('canMakeAndroidPayPayments');
     } else if (Platform.isIOS) {
-      Map<String, dynamic> options = {"network": networks};
+      Map<String, dynamic> options = {"networks": networks};
       return _channel.invokeMethod('canMakeApplePayPayments', options);
     } else
       throw UnimplementedError();

--- a/lib/src/stripe_payment.dart
+++ b/lib/src/stripe_payment.dart
@@ -33,10 +33,11 @@ class StripePayment {
   }
 
   /// https://tipsi.github.io/tipsi-stripe/docs/canMakeNativePayPayments.html
-  static Future<bool> canMakeNativePayPayments(Map<String, dynamic> options) async {
+  static Future<bool> canMakeNativePayPayments(List<String> networks) async {
     if (Platform.isAndroid) {
       return _channel.invokeMethod('canMakeAndroidPayPayments');
     } else if (Platform.isIOS) {
+      Map<String, dynamic> options = {"network": networks};
       return _channel.invokeMethod('canMakeApplePayPayments', options);
     } else
       throw UnimplementedError();


### PR DESCRIPTION
`.canMakeNativePayPayments([options])` allows a list of 'networks' to be passed to the Apply Pay equivalent method.
The Tipsi documentation lists this as `[options]`, suggesting a list; however, it specifically references the key 'networks' as an option to fill, requiring a map for implementation.

This led to an `-[NSObject(NSObject) doesNotRecognizeSelector:]` error on iOS, as an List was passed, which was then queried for a value by a key – an illegal operation for an NSArrayM.

This patch fixes this by making `canMakeNativePayPayments`'s argument a Map called 'options'.