### PR TITLE
Add stripeAccount for connect operations

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/util/InitializationOptions.java
+++ b/android/src/main/java/com/gettipsi/stripe/util/InitializationOptions.java
@@ -7,6 +7,7 @@ package com.gettipsi.stripe.util;
 public abstract class InitializationOptions {
 
   public static final String PUBLISHABLE_KEY = "publishableKey";
+  public static final String STRIPE_ACCOUNT = "stripeAccount";
   public static final String ANDROID_PAY_MODE_KEY = "androidPayMode";
   public static final String ANDROID_PAY_MODE_PRODUCTION = "production";
   public static final String ANDROID_PAY_MODE_TEST = "test";

--- a/android/src/main/java/de/jonasbark/stripepayment/StripePaymentPlugin.kt
+++ b/android/src/main/java/de/jonasbark/stripepayment/StripePaymentPlugin.kt
@@ -15,7 +15,8 @@ class StripePaymentPlugin(private val stripeModule: StripeModule) : MethodCallHa
         when (call.method) {
             "setOptions" -> stripeModule.init(
                 ReadableMap(call.argument("options")),
-                ReadableMap(call.argument("errorCodes"))
+                ReadableMap(call.argument("errorCodes")),
+                Promise(result)
             )
             "deviceSupportsAndroidPay" -> stripeModule.deviceSupportsAndroidPay(Promise(result));
             "canMakeAndroidPayPayments" -> stripeModule.canMakeAndroidPayPayments(Promise(result));

--- a/lib/src/stripe_payment.dart
+++ b/lib/src/stripe_payment.dart
@@ -3,15 +3,15 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import 'android_pay_payment_request.dart';
+import 'apple_pay_payment_request.dart';
+import 'card_form_payment_request.dart';
+import 'error_codes.dart';
 import 'payment_intent.dart';
 import 'payment_method.dart';
 import 'source.dart';
 import 'source_params.dart';
 import 'token.dart';
-import 'android_pay_payment_request.dart';
-import 'apple_pay_payment_request.dart';
-import 'card_form_payment_request.dart';
-import 'error_codes.dart';
 
 class StripePayment {
   static const MethodChannel _channel = const MethodChannel('stripe_payment');
@@ -153,12 +153,13 @@ class StripeOptions {
   final String publishableKey;
   final String merchantId;
   final String androidPayMode;
+  final String stripeAccount;
 
-  StripeOptions({@required this.publishableKey, this.merchantId, this.androidPayMode});
+  StripeOptions({@required this.publishableKey, this.merchantId, this.androidPayMode, this.stripeAccount});
 
   factory StripeOptions.fromJson(Map<String, dynamic> json) {
     return StripeOptions(
-        merchantId: json['merchantId'], publishableKey: json['publishableKey'], androidPayMode: json['androidPayMode']);
+        merchantId: json['merchantId'], publishableKey: json['publishableKey'], androidPayMode: json['androidPayMode'], stripeAccount: json['stripeAccount']);
   }
 
   Map<String, dynamic> toJson() {
@@ -166,6 +167,7 @@ class StripeOptions {
     if (this.merchantId != null) data['merchantId'] = this.merchantId;
     if (this.publishableKey != null) data['publishableKey'] = this.publishableKey;
     if (this.androidPayMode != null) data['androidPayMode'] = this.androidPayMode;
+    if (this.stripeAccount != null) data['stripeAccountId'] = this.stripeAccount;
     return data;
   }
 }

--- a/lib/src/stripe_payment.dart
+++ b/lib/src/stripe_payment.dart
@@ -17,8 +17,8 @@ class StripePayment {
   static const MethodChannel _channel = const MethodChannel('stripe_payment');
 
   /// https://tipsi.github.io/tipsi-stripe/docs/usage.html
-  static void setOptions(StripeOptions settings) {
-    _channel.invokeMethod('setOptions', {"options": settings.toJson(), "errorCodes": Errors.mapping});
+  static Future<void> setOptions(StripeOptions settings) {
+    return _channel.invokeMethod('setOptions', {"options": settings.toJson(), "errorCodes": Errors.mapping});
   }
 
   /// https://tipsi.github.io/tipsi-stripe/docs/usage.html
@@ -167,7 +167,7 @@ class StripeOptions {
     if (this.merchantId != null) data['merchantId'] = this.merchantId;
     if (this.publishableKey != null) data['publishableKey'] = this.publishableKey;
     if (this.androidPayMode != null) data['androidPayMode'] = this.androidPayMode;
-    if (this.stripeAccount != null) data['stripeAccountId'] = this.stripeAccount;
+    if (this.stripeAccount != null) data['stripeAccount'] = this.stripeAccount;
     return data;
   }
 }


### PR DESCRIPTION
I'm building an app that uses Stripe connect.
In order to confirmPayments and some other tasks I need to pass the accountId to the platform so the SDK will perform those actions with the connect account.

I made the change only Android just because I have 0 experience with Objective-C and I don't know how to make the same change there. 

I'm also resolving the result promise in the `init` method to perform actions ones the initialization is done.

I hope you find this change usefull and you have time to impement it for iOS too.