### PR TITLE
Avoid use of Platform.is* on flutter web

### DIFF
--- a/lib/src/error_codes.dart
+++ b/lib/src/error_codes.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 
 import 'package:flutter/material.dart';
 
@@ -34,7 +35,7 @@ class Errors {
     ).toJson(),
     "deviceNotSupportsNativePay": ErrorCode(
             errorCode: 'deviceNotSupportsNativePay',
-            description:
+            description: kIsWeb ? "Native Pay isn't supported in a web browser" :
                 Platform.isIOS ? 'This device does not support Apple Pay' : 'This device does not support Google Pay')
         .toJson(),
     "noPaymentRequest": ErrorCode(

--- a/lib/src/stripe_payment.dart
+++ b/lib/src/stripe_payment.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/foundation.dart';
 
 import 'android_pay_payment_request.dart';
 import 'apple_pay_payment_request.dart';
@@ -28,6 +29,10 @@ class StripePayment {
 
   /// https://tipsi.github.io/tipsi-stripe/docs/usage.html
   static Future<bool> deviceSupportsNativePay() async {
+    if (kIsWeb) {
+      return false;
+    }
+
     if (Platform.isIOS) {
       return _deviceSupportsApplePay();
     } else if (Platform.isAndroid) {
@@ -39,6 +44,10 @@ class StripePayment {
 
   /// https://tipsi.github.io/tipsi-stripe/docs/canMakeNativePayPayments.html
   static Future<bool> canMakeNativePayPayments(List<String> networks) async {
+    if (kIsWeb) {
+      throw UnimplementedError();
+    }
+
     if (Platform.isAndroid) {
       return _channel.invokeMethod('canMakeAndroidPayPayments');
     } else if (Platform.isIOS) {
@@ -55,6 +64,10 @@ class StripePayment {
   /// https://tipsi.github.io/tipsi-stripe/docs/paymentRequestWithNativePay.html
   static Future<Token> paymentRequestWithNativePay(
       {@required AndroidPayPaymentRequest androidPayOptions, @required ApplePayPaymentOptions applePayOptions}) {
+    if (kIsWeb) {
+      throw UnimplementedError();
+    }
+    
     if (Platform.isAndroid) {
       return _paymentRequestWithAndroidPay(androidPayOptions);
     } else if (Platform.isIOS) {
@@ -76,6 +89,10 @@ class StripePayment {
 
   /// https://tipsi.github.io/tipsi-stripe/docs/completeNativePayRequest.html
   static Future<void> completeNativePayRequest() async {
+    if (kIsWeb) {
+      throw UnimplementedError();
+    }
+
     if (Platform.isIOS) {
       return _channel.invokeMethod("completeApplePayRequest");
     } else if (Platform.isAndroid) {
@@ -86,6 +103,10 @@ class StripePayment {
 
   /// https://tipsi.github.io/tipsi-stripe/docs/cancelNativePayRequest.html
   static Future<void> cancelNativePayRequest() async {
+    if (kIsWeb) {
+      throw UnimplementedError();
+    }
+
     if (Platform.isIOS) {
       return _channel.invokeMethod("cancelApplePayRequest");
     } else if (Platform.isAndroid) {

--- a/lib/src/stripe_payment.dart
+++ b/lib/src/stripe_payment.dart
@@ -31,14 +31,14 @@ class StripePayment {
   static Future<bool> deviceSupportsNativePay() async {
     if (kIsWeb) {
       return false;
-    }
-
-    if (Platform.isIOS) {
-      return _deviceSupportsApplePay();
-    } else if (Platform.isAndroid) {
-      return _deviceSupportsAndroidPay();
     } else {
-      return false;
+      if (Platform.isIOS) {
+        return _deviceSupportsApplePay();
+      } else if (Platform.isAndroid) {
+        return _deviceSupportsAndroidPay();
+      } else {
+        return false;
+      }
     }
   }
 
@@ -46,15 +46,15 @@ class StripePayment {
   static Future<bool> canMakeNativePayPayments(List<String> networks) async {
     if (kIsWeb) {
       throw UnimplementedError();
+    } else {
+      if (Platform.isAndroid) {
+        return _channel.invokeMethod('canMakeAndroidPayPayments');
+      } else if (Platform.isIOS) {
+        Map<String, dynamic> options = {"networks": networks};
+        return _channel.invokeMethod('canMakeApplePayPayments', options);
+      } else
+        throw UnimplementedError();
     }
-
-    if (Platform.isAndroid) {
-      return _channel.invokeMethod('canMakeAndroidPayPayments');
-    } else if (Platform.isIOS) {
-      Map<String, dynamic> options = {"networks": networks};
-      return _channel.invokeMethod('canMakeApplePayPayments', options);
-    } else
-      throw UnimplementedError();
   }
 
   static Future<bool> _deviceSupportsAndroidPay() => _channel.invokeMethod("deviceSupportsAndroidPay");
@@ -66,14 +66,14 @@ class StripePayment {
       {@required AndroidPayPaymentRequest androidPayOptions, @required ApplePayPaymentOptions applePayOptions}) {
     if (kIsWeb) {
       throw UnimplementedError();
+    } else {
+      if (Platform.isAndroid) {
+        return _paymentRequestWithAndroidPay(androidPayOptions);
+      } else if (Platform.isIOS) {
+        return _paymentRequestWithApplePay(applePayOptions);
+      } else
+        throw UnimplementedError();
     }
-    
-    if (Platform.isAndroid) {
-      return _paymentRequestWithAndroidPay(androidPayOptions);
-    } else if (Platform.isIOS) {
-      return _paymentRequestWithApplePay(applePayOptions);
-    } else
-      throw UnimplementedError();
   }
 
   static Future<Token> _paymentRequestWithAndroidPay(AndroidPayPaymentRequest options) async {
@@ -91,28 +91,28 @@ class StripePayment {
   static Future<void> completeNativePayRequest() async {
     if (kIsWeb) {
       throw UnimplementedError();
+    } else {
+      if (Platform.isIOS) {
+        return _channel.invokeMethod("completeApplePayRequest");
+      } else if (Platform.isAndroid) {
+        return null;
+      } else
+        throw UnimplementedError();
     }
-
-    if (Platform.isIOS) {
-      return _channel.invokeMethod("completeApplePayRequest");
-    } else if (Platform.isAndroid) {
-      return null;
-    } else
-      throw UnimplementedError();
   }
 
   /// https://tipsi.github.io/tipsi-stripe/docs/cancelNativePayRequest.html
   static Future<void> cancelNativePayRequest() async {
     if (kIsWeb) {
       throw UnimplementedError();
+    } else {
+      if (Platform.isIOS) {
+        return _channel.invokeMethod("cancelApplePayRequest");
+      } else if (Platform.isAndroid) {
+        return null;
+      } else
+        throw UnimplementedError();
     }
-
-    if (Platform.isIOS) {
-      return _channel.invokeMethod("cancelApplePayRequest");
-    } else if (Platform.isAndroid) {
-      return null;
-    } else
-      throw UnimplementedError();
   }
 
   /// https://tipsi.github.io/tipsi-stripe/docs/paymentRequestWithCardForm.html


### PR DESCRIPTION
Since Platform.is* is not currently supported on flutter's web implementation, using it results in the `Error: Unsupported operation: Platform._operatingSystem` error. By using the kIsWeb constant provided by the flutter team (documented [here](https://api.flutter.dev/flutter/foundation/kIsWeb-constant.html)) we can prevent this ever being called on the web.