### PR TITLE
Support Apple Pay inline setup

### DIFF
--- a/ios/Classes/TPSStripeManager.m
+++ b/ios/Classes/TPSStripeManager.m
@@ -863,8 +863,7 @@ void initializeTPSPaymentNetworksWithConditionalMappings() {
     [paymentRequest setShippingMethods:shippingMethods];
     [paymentRequest setShippingType:shippingType];
 
-    if ([self canSubmitPaymentRequest:paymentRequest rejecter:reject]) {
-        PKPaymentAuthorizationViewController *paymentAuthorizationVC = [[PKPaymentAuthorizationViewController alloc] initWithPaymentRequest:paymentRequest];
+    PKPaymentAuthorizationViewController *paymentAuthorizationVC = [[PKPaymentAuthorizationViewController alloc] initWithPaymentRequest:paymentRequest];
         paymentAuthorizationVC.delegate = self;
 
         // move to the end of main queue
@@ -873,11 +872,6 @@ void initializeTPSPaymentNetworksWithConditionalMappings() {
         dispatch_async(dispatch_get_main_queue(), ^{
             [RCTPresentedViewController() presentViewController:paymentAuthorizationVC animated:YES completion:nil];
         });
-    } else {
-        // There is a problem with your Apple Pay configuration.
-        [self resetPromiseCallbacks];
-        requestIsCompleted = YES;
-    }
 }
 
 -(void)openApplePaySetup {

--- a/ios/Classes/TPSStripeManager.m
+++ b/ios/Classes/TPSStripeManager.m
@@ -864,14 +864,14 @@ void initializeTPSPaymentNetworksWithConditionalMappings() {
     [paymentRequest setShippingType:shippingType];
 
     PKPaymentAuthorizationViewController *paymentAuthorizationVC = [[PKPaymentAuthorizationViewController alloc] initWithPaymentRequest:paymentRequest];
-        paymentAuthorizationVC.delegate = self;
+    paymentAuthorizationVC.delegate = self;
 
-        // move to the end of main queue
-        // allow the execution of hiding modal
-        // to be finished first
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [RCTPresentedViewController() presentViewController:paymentAuthorizationVC animated:YES completion:nil];
-        });
+    // move to the end of main queue
+    // allow the execution of hiding modal
+    // to be finished first
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [RCTPresentedViewController() presentViewController:paymentAuthorizationVC animated:YES completion:nil];
+    });
 }
 
 -(void)openApplePaySetup {


### PR DESCRIPTION
With previous versions of iOS, if a payment sheet was presented without the user having any cards added to Apple Pay, an error would be returned. Starting with iOS 11, this behavior changed; instead of returning an error, the `PKPaymentAuthorizationViewController` displays a modal that lets the user set up Apple Pay without ever leaving the app (known as Apple Pay inline setup). 

This PR tweaks the `paymentRequestWithApplePay` method to support Apple Pay's inline setup, which is Apple's recommended way of allowing users to set up Apple Pay in-app if they've never used Apple Pay but their device supports it.

I've basically just removed the `canSubmitPaymentRequest` check so that the `PKPaymentAuthorizationViewController` is presented even if the user hasn't added any cards to Apple Pay yet, which then triggers the inline setup modal. Not sure if there's a more elegant way to do this, so feel free to comment and/or make further tweaks. 

As a side note, I initially thought that the `openApplePaySetup` method in `TPSStripeManager.m` would trigger Apple Pay's inline setup, but it actually just takes the user to the Wallet app. The great thing about inline setup is that it all happens in-app, so when the user is done adding a card, they're taken right back to the checkout screen automatically instead of being left in the Wallet app.