### PR TITLE
Update AppInfo for flutter_stripe_payment

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/StripeModule.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeModule.java
@@ -40,9 +40,9 @@ public class StripeModule extends ReactContextBaseJavaModule {
   // Relevant Docs:
   // - https://stripe.dev/stripe-ios/docs/Classes/STPAppInfo.html https://stripe.dev/stripe-android/com/stripe/android/AppInfo.html
   // - https://stripe.com/docs/building-plugins#setappinfo
-  private static final String APP_INFO_NAME    = "tipsi-stripe";
-  private static final String APP_INFO_URL     = "https://github.com/tipsi/tipsi-stripe";
-  private static final String APP_INFO_VERSION = "8.x";
+  private static final String APP_INFO_NAME    = "flutter_stripe_payment";
+  private static final String APP_INFO_URL     = "https://github.com/jonasbark/flutter_stripe_payment";
+  private static final String APP_INFO_VERSION = "1.x";
   public static final String CLIENT_SECRET = "clientSecret";
 
   private static StripeModule sInstance = null;

--- a/ios/Classes/TPSStripeManager.m
+++ b/ios/Classes/TPSStripeManager.m
@@ -17,10 +17,10 @@
 // Relevant Docs:
 // - https://stripe.dev/stripe-ios/docs/Classes/STPAppInfo.html https://stripe.dev/stripe-android/com/stripe/android/AppInfo.html
 // - https://stripe.com/docs/building-plugins#setappinfo
-NSString * const TPSAppInfoName = @"tipsi-stripe";
-NSString * const TPSAppInfoPartnerId = @"tipsi-stripe";
-NSString * const TPSAppInfoURL = @"https://github.com/tipsi/tipsi-stripe";
-NSString * const TPSAppInfoVersion = @"8.x";
+NSString * const TPSAppInfoName = @"flutter_stripe_payment";
+NSString * const TPSAppInfoPartnerId = @"flutter_stripe_payment";
+NSString * const TPSAppInfoURL = @"https://github.com/jonasbark/flutter_stripe_payment";
+NSString * const TPSAppInfoVersion = @"1.x";
 
 typedef NSString * TPSErrorKey NS_EXTENSIBLE_STRING_ENUM;
 #define TPSErrorKeyDefine(Key, string) TPSErrorKey const kErrorKey ## Key = string


### PR DESCRIPTION
Hi @jonasbark! I was recently taking inventory of plugins wrapping our iOS and Android SDKs, and I noticed that your plugin is sending a user agent of `tipsi-stripe`. Would you mind if I changed this to `flutter_stripe_payment`? It would help us provide better support for our users when they call in with integration questions.

Thanks!