### PR TITLE
Recreate apiClient when authenticatePaymentIntent is called

### DIFF
--- a/ios/Classes/TPSStripeManager.m
+++ b/ios/Classes/TPSStripeManager.m
@@ -454,6 +454,7 @@ void initializeTPSPaymentNetworksWithConditionalMappings() {
     promiseResolver = resolve;
     promiseRejector = reject;
 
+    STPAPIClient *api = self.newAPIClient;
     // From example in step 3 of https://stripe.com/docs/payments/payment-intents/ios#manual-confirmation-ios
     [[STPPaymentHandler sharedHandler] handleNextActionForPayment:clientSecret
                                         withAuthenticationContext:self


### PR DESCRIPTION
This commit fixes #258 