### PR TITLE
[feature] support saving payment method to stripe customer

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:stripe_payment/stripe_payment.dart';
-import 'dart:io';
 
 void main() {
   runApp(new MyApp());
@@ -172,6 +172,31 @@ class _MyAppState extends State<MyApp> {
                             PaymentIntent(
                               clientSecret: _paymentIntentClientSecret,
                               paymentMethodId: _paymentMethod.id,
+                            ),
+                          ).then((paymentIntent) {
+                            _scaffoldKey.currentState.showSnackBar(SnackBar(
+                                content: Text(
+                                    'Received ${paymentIntent.paymentIntentId}')));
+                            setState(() {
+                              _paymentIntent = paymentIntent;
+                            });
+                          }).catchError(setError);
+                        },
+            ),
+            RaisedButton(
+              child: Text(
+                "Confirm Payment Intent with saving payment method",
+                textAlign: TextAlign.center,
+              ),
+              onPressed:
+                  _paymentMethod == null || _paymentIntentClientSecret == null
+                      ? null
+                      : () {
+                          StripePayment.confirmPaymentIntent(
+                            PaymentIntent(
+                              clientSecret: _paymentIntentClientSecret,
+                              paymentMethodId: _paymentMethod.id,
+                              isSavingPaymentMethod: true,
                             ),
                           ).then((paymentIntent) {
                             _scaffoldKey.currentState.showSnackBar(SnackBar(

--- a/lib/src/payment_intent.dart
+++ b/lib/src/payment_intent.dart
@@ -6,12 +6,14 @@ class PaymentIntent {
   String paymentMethodId;
   String returnURL;
   String clientSecret;
+  bool isSavingPaymentMethod;
 
   PaymentIntent({
     this.paymentMethod,
     this.paymentMethodId,
     this.returnURL,
     @required this.clientSecret,
+    this.isSavingPaymentMethod,
   });
 
   Map<String, dynamic> toJson() {
@@ -19,9 +21,12 @@ class PaymentIntent {
     if (this.paymentMethod != null) {
       data['paymentMethod'] = this.paymentMethod.toJson();
     }
-    if (this.paymentMethodId != null) data['paymentMethodId'] = this.paymentMethodId;
+    if (this.paymentMethodId != null)
+      data['paymentMethodId'] = this.paymentMethodId;
     if (this.returnURL != null) data['returnURL'] = this.returnURL;
     if (this.clientSecret != null) data['clientSecret'] = this.clientSecret;
+    if (this.isSavingPaymentMethod != null)
+      data['savePaymentMethod'] = this.isSavingPaymentMethod;
     return data;
   }
 }
@@ -31,7 +36,8 @@ class PaymentIntentResult {
   String paymentIntentId;
   String paymentMethodId;
 
-  PaymentIntentResult({this.status, this.paymentIntentId, this.paymentMethodId});
+  PaymentIntentResult(
+      {this.status, this.paymentIntentId, this.paymentMethodId});
 
   factory PaymentIntentResult.fromJson(Map<dynamic, dynamic> json) {
     return PaymentIntentResult(
@@ -43,9 +49,11 @@ class PaymentIntentResult {
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = new Map<String, dynamic>();
-    if (this.paymentIntentId != null) data['paymentIntentId'] = this.paymentIntentId;
+    if (this.paymentIntentId != null)
+      data['paymentIntentId'] = this.paymentIntentId;
     if (this.status != null) data['status'] = this.status;
-    if (this.paymentMethodId != null) data['paymentMethodId'] = this.paymentMethodId;
+    if (this.paymentMethodId != null)
+      data['paymentMethodId'] = this.paymentMethodId;
     return data;
   }
 }


### PR DESCRIPTION
## Objective
Support saving payment method into customer which was created by backend
#187 

## Instruction
By the Stripe [documentation](https://stripe.com/docs/payments/save-during-payment). We can charge a customer for an e-commerce order and store the details for future purchases. With this being said, we can save the payment intent if current payment transection is successfully confirmed by user.

We can accomplish the flow by following steps:

Before saving payment intent
1. create payment method by card
2. create payment intent by clientSecret and  payment method id
2. confirm payment intent with savePaymentMethod = true

After saving payment intent
1. retrieve list of payment method by using [Stripe API](https://stripe.com/docs/api/payment_methods/list) in server side
2. create payment intent by clientSecret and  payment method id
3. confirm payment intent
