### PR TITLE
Add missing UnionPay card brand on ios

### DIFF
--- a/ios/Classes/TPSStripeManager.m
+++ b/ios/Classes/TPSStripeManager.m
@@ -1490,6 +1490,8 @@ void initializeTPSPaymentNetworksWithConditionalMappings() {
             return @"diners";
         case STPCardBrandMasterCard:
             return @"mastercard";
+        case STPCardBrandUnionPay:
+            return @"unionpay";
         case STPCardBrandUnknown:
         default:
             return @"unknown";


### PR DESCRIPTION
Close https://github.com/jonasbark/flutter_stripe_payment/issues/267